### PR TITLE
Make `reset` use repeated command for confirmation.

### DIFF
--- a/src/main/java/io/github/moonlight_maya/limits_strawberries/data/BerryMap.java
+++ b/src/main/java/io/github/moonlight_maya/limits_strawberries/data/BerryMap.java
@@ -79,7 +79,7 @@ public class BerryMap {
 	//Returns null on success.
 	public Text createVirtualBerry(String key) {
 		if (virtualBerries.containsKey(key))
-			return Text.translatable("limits_strawberies.command.berry_create_already_exists", key);
+			return Text.translatable("limits_strawberries.command.berry_create_already_exists", key);
 		UUID berryUUID;
 		do berryUUID = UUID.randomUUID(); while (!addBerryIfNeeded(berryUUID));
 		virtualBerries.put(key, berryUUID);

--- a/src/main/resources/assets/limits_strawberries/lang/en_us.json
+++ b/src/main/resources/assets/limits_strawberries/lang/en_us.json
@@ -45,21 +45,23 @@
   "item.limits_strawberries.strawberry": "Strawberry",
   "limits_strawberries.item.edible": "Edible: Eat to earn this strawberry!",
 
-  "limits_strawberies.command.failure_invalid_key": "Failed to execute command. No berry with key %s.",
-  "limits_strawberies.command.failure_too_long": "String too long! Maximum length %d.",
+  "limits_strawberries.command.failure_invalid_key": "Failed to execute command. No berry with key %s.",
+  "limits_strawberries.command.failure_too_long": "String too long! Maximum length %d.",
+  "limits_strawberries.command.failure_non_player": "Command must be called by a player!",
 
-  "limits_strawberries.command.reset_confirmation": "Are you sure you want to reset all berry progress? You will lose ALL of your collected berries. To confirm, type \"/berry reset confirm %d\". To cancel, run the command with a different number.",
-  "limits_strawberries.command.reset_confirm_before_request": "Could not confirm. You need to request first with \"/berry reset\".",
-  "limits_strawberries.command.reset_canceled": "Reset canceled successfully.",
-  "limits_strawberries.command.reset_confirmed": "Reset confirmed. Your berries have been reset.",
+  "limits_strawberries.command.confirm_prompt": "Confirm using %s",
 
-  "limits_strawberies.command.berry_create_success": "Successfully created berry %s.",
+  "limits_strawberries.command.reset_command": "/berry reset",
+  "limits_strawberries.command.reset_warning": "Are you sure you want to reset all berry progress? You will lose ALL of your collected berries.",
+  "limits_strawberries.command.reset_confirmed": "Your berry progress has been reset.",
 
-  "limits_strawberies.command.berry_delete_success": "Successfully deleted berry with key %s.",
-  "limits_strawberies.command.berry_delete_failure_not_exist": "Failed to delete berry because somehow it didn't exist??? This is a bug lol, try to report with a reproducible example.",
+  "limits_strawberries.command.berry_create_success": "Successfully created berry %s.",
 
-  "limits_strawberies.command.berry_list_none": "There are no virtual berries.",
-  "limits_strawberies.command.berry_list_result": "%s.",
+  "limits_strawberries.command.berry_delete_success": "Successfully deleted berry with key %s.",
+  "limits_strawberries.command.berry_delete_failure_not_exist": "Failed to delete berry because somehow it didn't exist??? This is a bug lol, try to report with a reproducible example.",
 
-  "limits_strawberies.command.berry_grant_success": "Successfully granted berry to %d players."
+  "limits_strawberries.command.berry_list_none": "There are no virtual berries.",
+  "limits_strawberries.command.berry_list_result": "%s.",
+
+  "limits_strawberries.command.berry_grant_success": "Successfully granted berry to %d players."
 }


### PR DESCRIPTION
Also fixes some typos (lang strings mostly)

This solution wraps each command method in an wrapper/unwrapping function, which uses an overloaded signature to check if the method requires a player source. The unwrapping function tries to get the player, and saves the command that was run by their UUID.